### PR TITLE
Set GA4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,13 @@ jobs:
           set -eux
           cd docs
           mkdir build
+      - name: Validate GA4_TRACKING_ID
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.GA4_TRACKING_ID }}" ]; then
+            echo "Error: GA4_TRACKING_ID is not set"
+            exit 1
+          fi
       - name: Jupyter Book 
         env:
           GA4_TRACKING_ID: ${{ secrets.GA4_TRACKING_ID }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,8 +45,14 @@ jobs:
           cd docs
           mkdir build
       - name: Jupyter Book 
+        env:
+          GA4_TRACKING_ID: ${{ secrets.GA4_TRACKING_ID }}
         run: |
           cd docs
+          # Replace GA4_TRACKING_ID placeholder with actual value from secrets
+          # Using | as delimiter to avoid issues with / in the GA4 ID
+          sed -i "s|GA4_TRACKING_ID|${GA4_TRACKING_ID}|g" en/_config.yml
+          sed -i "s|GA4_TRACKING_ID|${GA4_TRACKING_ID}|g" ja/_config.yml
           sh doc_build.sh 
       - name: du -a 
         shell: bash

--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -32,6 +32,8 @@ html:
   favicon: ../favicon.ico
   use_issues_button: true
   use_repository_button: true
+  analytics:
+    google_analytics_id: ${{ secrets.GA4_TRACKING_ID }}
 
   extra_js:
     - _static/language_switch.js

--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -33,7 +33,7 @@ html:
   use_issues_button: true
   use_repository_button: true
   analytics:
-    google_analytics_id: ${{ secrets.GA4_TRACKING_ID }}
+    google_analytics_id: GA4_TRACKING_ID
 
   extra_js:
     - _static/language_switch.js

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -33,6 +33,8 @@ html:
   favicon: ../favicon.ico
   use_issues_button: true
   use_repository_button: true
+  analytics:
+    google_analytics_id: ${{ secrets.GA4_TRACKING_ID }}
 
   extra_js:
     - _static/language_switch.js

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -34,7 +34,7 @@ html:
   use_issues_button: true
   use_repository_button: true
   analytics:
-    google_analytics_id: ${{ secrets.GA4_TRACKING_ID }}
+    google_analytics_id: GA4_TRACKING_ID
 
   extra_js:
     - _static/language_switch.js


### PR DESCRIPTION
## Changes
I seted GA4.

Using direct GitHub Actions syntax (${{ secrets.GA4_TRACKING_ID }}) in Jupyter Book config files doesn't work because the static site generator treats it as literal text. Instead, we use a placeholder that gets replaced by the actual secret value during the GitHub Actions workflow before the documentation is built.