### PR TITLE
jij-cimodのバージョン要件を1.7.0から1.8.0に更新

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     dimod < 0.13.0
     scipy >= 1.7.3, < 1.12.0
     requests >= 2.28.0, < 2.32.0
-    jij-cimod >= 1.6.0, < 1.7.0
+    jij-cimod >= 1.6.0, < 1.8.0
     typing-extensions >= 4.2.0
 
 [options.extras_require]


### PR DESCRIPTION
This pull request updates the dependency version range for `jij-cimod` in the `setup.cfg` file to allow compatibility with newer versions while maintaining constraints for stability.

Dependency update:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L59-R59): Updated the version range of `jij-cimod` from `< 1.7.0` to `< 1.8.0` to support newer releases.## Changes

- Please describe changes

## Related issue

- Please describe the related issue for this PR.

## Sample code

- Please note a sample code here if possible.

## Destructive changes

- Please note if there are destructive changes in this PR.

## Misc
